### PR TITLE
Update waveshape label when changed by control

### DIFF
--- a/raffo_gui.cpp
+++ b/raffo_gui.cpp
@@ -40,7 +40,7 @@ RaffoSynthGUI::RaffoSynthGUI(const std::string& URI) {
 		
 		range[i]->signal_value_changed().connect(compose(bind<0>(mem_fun(*this, &RaffoSynthGUI::write_control), m_range0 + i), mem_fun(*range[i], &HScale::get_value)));
 	 	
-		wave[i]->signal_value_changed().connect(compose(bind<0>(mem_fun(*this, &RaffoSynthGUI::write_control), m_wave0 + i), mem_fun(*wave[i], &HScale::get_value)));
+		wave[i]->signal_value_changed().connect(compose(bind<0>(mem_fun(*this, &RaffoSynthGUI::write_waveshape), m_wave0 + i), mem_fun(*wave[i], &HScale::get_value)));
 		
 		vol[i]->signal_value_changed().connect(compose(bind<0>(mem_fun(*this, &RaffoSynthGUI::write_control), m_vol0 + i), mem_fun(*vol[i], &HScale::get_value)));
 		
@@ -388,6 +388,12 @@ void RaffoSynthGUI::load_preset(){
 	
 	f.close();
 	
+}
+
+void RaffoSynthGUI::write_waveshape(int control, int shape)
+{
+	wave_label[control - m_wave0]->set_text(waveshapes[shape]);
+	write_control(control, shape);
 }
 
 static int _ = RaffoSynthGUI::register_class("http://example.org/raffo/gui");

--- a/raffo_gui.h
+++ b/raffo_gui.h
@@ -54,6 +54,8 @@ protected:
 	Entry* filename;
 	
 	char* waveshapes[4] = {"Triangle", "Saw", "Square", "Pulse"};
+	void write_waveshape(int control, int shape);
+
 	//static char* format_value(GtkScale *scale, int value){
      //   return str("-->%d<--", value);}
 	


### PR DESCRIPTION
Hi. Usually the waveshape text would not update after it is has been changed by moving the slider.
This commit will solve the problem.